### PR TITLE
fix: patch granite to fix version dependency resolution issue

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -22,7 +22,7 @@ dependencies:
 
   granite:
     github: amberframework/granite
-    version: ~> 0.23.1
+    branch: master
 
   quartz_mailer:
     github: amberframework/quartz-mailer


### PR DESCRIPTION
relates to Homebrew/homebrew-core#138207

fixes #1334 

This is a workaround until there is a new release for `granite`